### PR TITLE
Broadcast elections

### DIFF
--- a/communities/ElectionCommunity.py
+++ b/communities/ElectionCommunity.py
@@ -1,41 +1,103 @@
-import os
+import json
 
 from ipv8.community import Community, CommunitySettings
 from ipv8.lazy_community import lazy_wrapper
 from ipv8.peer import Peer
 
-from messages.message import MyMessage
+from config import COMMUNITY_ID
+from messages.election_message import ElectionMessage
+from models.election import Election
+from models.vote import Vote
+from storage.json_store import JSONStore
+
 
 class ElectionCommunity(Community):
-    community_id = os.urandom(20)
+    """
+    Community to manage and propagate elections and votes among peers.
+    1. On start, broadcasts all known elections to connected peers.
+    2. On receiving an election, adds it to the store if unknown and propagates it further.
+    3. Provides a method to broadcast newly created elections to peers.
+
+    Args:
+        settings (CommunitySettings): Configuration for the community, including stores and callbacks.
+    """
+    community_id = COMMUNITY_ID
 
     def __init__(self, settings: CommunitySettings) -> None:
         super().__init__(settings)
 
+        self.election_store: JSONStore[Election] = settings.election_store
+        self.vote_store: JSONStore[Vote] = settings.vote_store
+        self.election_added = settings.election_added
+
         # Register the message handlers for messages.
-        self.add_message_handler(MyMessage, self.on_message)
+        self.add_message_handler(ElectionMessage, self.on_message)
 
-        self.elections = []
+    def on_start(self) -> None:
+        """
+        Called when the community starts. Sets up periodic broadcasting of known elections to peers.
 
-    def started(self) -> None:
+        :return: None
+        """
         async def start_communication() -> None:
-            if not self.elections:
-                # If we have not started counting, try boostrapping
-                # communication with our other known peers.
-                for p in self.get_peers():
-                    self.ez_send(p, MyMessage(666))
-            else:
-                self.cancel_pending_task("start_communication")
+            """
+            Periodically broadcasts all known elections to connected peers.
+
+            :return: None
+            """
+            elections = self.election_store.get_all()
+
+            if not elections:
+                return
+
+            print(f"{self.my_peer}: Broadcasting {len(elections)} elections to peers.")
+
+            for election in elections:
+                payload = ElectionMessage(election_json=json.dumps(election.to_dict()))
+                for peer in self.get_peers():
+                    self.ez_send(peer, payload)
 
         # We register an asyncio task with this overlay.
         # This makes sure that the task ends when this overlay is unloaded.
-        # We call the "start_communication" function every 5.0 seconds, starting now.
-        self.register_task("start_communication", start_communication, interval=5.0, delay=0)
+        # We call the "start_communication" function every minute, starting now.
+        self.register_task("start_communication", start_communication, interval=60.0, delay=0)
 
-    @lazy_wrapper(MyMessage)
-    def on_message(self, peer: Peer, payload: MyMessage) -> None:
-        # Update our known elections.
-        self.elections.append(payload.electionId)
-        print(self.my_peer, "last election:", self.elections[-1])
+    @lazy_wrapper(ElectionMessage)
+    def on_message(self, peer: Peer, payload: ElectionMessage) -> None:
+        """
+        Handles incoming election messages from peers. Adds unknown elections to the store and propagates them.
+
+        :param peer: Peer that sent the message.
+        :param payload: Received election message.
+        :return: None
+        """
+        election = Election.from_dict(json.loads(payload.election_json))
+
+        print(f"{self.my_peer}: Received election {election.id} from peer {peer}.")
+
+        # Update store of known elections.
+        if self.election_store.get(election.id):
+            print(f"{self.my_peer}: Already knew about election {election.id}. Nothing updated.")
+            return
+
+        self.election_store.add(election)
+        self.election_added()
+
         # Then synchronize with the rest of the network again.
-        # self.ez_send(peer, MyMessage(self.elections[-1]))
+        for p in self.get_peers():
+            if p == peer:
+                continue
+            self.ez_send(p, payload)
+
+    def on_create_election(self, election: Election) -> None:
+        """
+        Broadcasts a newly created election to all connected peers.
+
+        :param election: Election to broadcast.
+        :return: None
+        """
+        payload = ElectionMessage(election_json=json.dumps(election.to_dict()))
+
+        for peer in self.get_peers():
+            print(f"{self.my_peer}: Sending election {election.id} to peer {peer}.")
+            self.ez_send(peer, payload)

--- a/config.py
+++ b/config.py
@@ -1,3 +1,6 @@
+import hashlib
+
 from typing import Final
 
 DATA_PATH: Final[str] = "data/"
+COMMUNITY_ID: Final[bytes] = hashlib.sha1(b"ElectionCommunity").digest()

--- a/main.py
+++ b/main.py
@@ -1,43 +1,127 @@
+import asyncio
 import os
+import threading
 
 from ipv8.configuration import ConfigBuilder, default_bootstrap_defs, Strategy, WalkerDefinition
 from ipv8_service import IPv8
-from ipv8.util import run_forever
 from pathlib import Path
+from typing import Callable, Optional
 
 from communities.ElectionCommunity import ElectionCommunity
 from config import DATA_PATH
 from models.election import Election
+from models.person import Person
 from models.vote import Vote
 from storage.json_store import JSONStore
 from ui.app import Application
 
-def main():
+# -----------------------------
+# IPv8 startup / community setup
+# -----------------------------
+async def start_community(
+    user_id: str,
+    election_store: JSONStore[Election],
+    vote_store: JSONStore[Vote],
+    election_added: Callable[[], None]
+) -> ElectionCommunity:
+    builder = ConfigBuilder().clear_keys().clear_overlays()
+
+    os.makedirs("keys", exist_ok=True)
+    builder.add_key("my peer", "curve25519", f"keys/{user_id}.pem")
+
+    builder.add_overlay(
+        overlay_class="ElectionCommunity",
+        key_alias="my peer",
+        walkers=[WalkerDefinition(Strategy.RandomWalk, 10, {"timeout": 3.0})],
+        bootstrappers=default_bootstrap_defs,
+        initialize={
+            "election_store": election_store,
+            "vote_store": vote_store,
+            "election_added": election_added
+        },
+        on_start=[("on_start",)]
+    )
+
+    ipv8 = IPv8(builder.finalize(), extra_communities={"ElectionCommunity": ElectionCommunity})
+    await ipv8.start()
+
+    # Return the actual overlay instance
+    return next(o for o in ipv8.overlays if isinstance(o, ElectionCommunity))
+
+def start_background_event_loop() -> tuple[asyncio.AbstractEventLoop, threading.Thread]:
+    loop = asyncio.new_event_loop()
+
+    def _loop_thread() -> None:
+        asyncio.set_event_loop(loop)
+        loop.run_forever()
+
+    thread = threading.Thread(target=_loop_thread, daemon=True)
+    thread.start()
+    return loop, thread
+
+# -----------------------------
+# App entrypoint
+# -----------------------------
+def main() -> None:
+    # --- Session user ---
+    user = Person()  # Person generates a random ID by default
+
+    # --- Data stores ---
     election_store = JSONStore[Election](
-        path=Path(DATA_PATH + "elections.json"),
+        path=Path(DATA_PATH + user.id + "/elections.json"),
         model_factory=Election.from_dict,
         dictify=lambda e: e.to_dict()
     )
     vote_store = JSONStore[Vote](
-        path=Path(DATA_PATH + "votes.json"),
+        path=Path(DATA_PATH + user.id + "/votes.json"),
         model_factory=Vote.from_dict,
         dictify=lambda v: v.to_dict()
     )
-    app = Application(election_store, vote_store)
-    app.run()
 
-async def start_communities(n: int) -> None:
-    for i in range(0, n):
-        builder = ConfigBuilder().clear_keys().clear_overlays()
-        os.makedirs("keys", exist_ok=True)
-        builder.add_key("my peer", "medium", f"keys/ec{i}.pem")
-        builder.add_overlay("ElectionCommunity", "my peer",
-                            [WalkerDefinition(Strategy.RandomWalk,
-                                              10, {"timeout": 3.0})],
-                            default_bootstrap_defs, {}, [("started",)])
-        await IPv8(builder.finalize(),
-                   extra_communities={"ElectionCommunity": ElectionCommunity}).start()
-    await run_forever()
+    # --- Shared state (overlay becomes available after IPv8 starts) ---
+    community_ref: dict[str, Optional[ElectionCommunity]] = {"overlay": None}
+
+    # --- IPv8 background loop ---
+    loop, thread = start_background_event_loop()
+
+    # --- UI callbacks ---
+    def broadcast_new_election(election: Election) -> None:
+        overlay: Optional[ElectionCommunity] = community_ref["overlay"]
+        if overlay is None:
+            # Community not ready yet; could queue these if needed.
+            return
+        loop.call_soon_threadsafe(overlay.on_create_election, election)
+
+    # --- UI creation (main thread) ---
+    app = Application(user, election_store, vote_store, broadcast_new_election)
+
+    # --- IPv8 -> UI callback (thread-safe via Tk) ---
+    def election_added() -> None:
+        app.root.after(0, lambda: app.list_frame.load(app.repo.get_all()))
+
+    # --- Start IPv8 / overlay on background loop ---
+    async def start_and_capture() -> None:
+        overlay = await start_community(user.id, election_store, vote_store, election_added)
+        community_ref["overlay"] = overlay
+
+    fut = asyncio.run_coroutine_threadsafe(start_and_capture(), loop)
+
+    def _done_callback(f: asyncio.Future[None]) -> None:
+        try:
+            f.result(timeout=10)  # will re-raise any exception from the coroutine
+        except Exception as e:
+            print("IPv8 startup did not complete:", repr(e))
+            raise
+
+    fut.add_done_callback(_done_callback)
+
+    # --- Run UI ---
+    try:
+        app.run()
+    finally:
+        # Stop the background loop when the application exits
+        loop.call_soon_threadsafe(loop.stop)
+        thread.join(timeout=1)
 
 if __name__ == "__main__":
     main()

--- a/messages/election_message.py
+++ b/messages/election_message.py
@@ -1,0 +1,16 @@
+from dataclasses import dataclass
+
+from ipv8.messaging.payload_dataclass import DataClassPayload
+
+@dataclass
+class ElectionMessage(DataClassPayload[1]):
+    """
+    Message to propagate election data in JSON format.
+
+    Attributes:
+        election_json (str): The election data serialized as a JSON string.
+    """
+    election_json: str
+
+# Force schema generation once on import
+_ = ElectionMessage(election_json="")

--- a/messages/message.py
+++ b/messages/message.py
@@ -1,7 +1,0 @@
-from dataclasses import dataclass
-
-from ipv8.messaging.payload_dataclass import DataClassPayload
-
-@dataclass
-class MyMessage(DataClassPayload[1]):
-    electionId: int

--- a/storage/json_store.py
+++ b/storage/json_store.py
@@ -1,4 +1,5 @@
 import json
+import os
 
 from pathlib import Path
 from typing import Any, Callable, Dict, Generic, List, Optional, TypeVar
@@ -45,6 +46,9 @@ class JSONStore(Generic[T]):
 
         :return: None
         """
+        if not self.path.parent.exists():
+            os.makedirs(self.path.parent, exist_ok=True)
+
         with open(self.path, "w", encoding="utf-8") as fh:
             json.dump([self._dictify(obj) for obj in self._data], fh, indent=2)
 

--- a/ui/app.py
+++ b/ui/app.py
@@ -1,4 +1,5 @@
 from tkinter import Tk
+from typing import Callable
 
 from models.election import Election
 from models.person import Person
@@ -24,13 +25,20 @@ class Application:
         election_store (JSONStore[Election]): Store for elections.
         vote_store (JSONStore[Vote]): Store for votes.
     """
-    def __init__(self, election_store: JSONStore[Election], vote_store: JSONStore[Vote]):
+    def __init__(
+        self,
+        user: Person,
+        election_store: JSONStore[Election],
+        vote_store: JSONStore[Vote],
+        broadcast_new_election: Callable[[Election], None]
+    ):
+        self.user = user
+
         self.election_store = election_store
         self.vote_store = vote_store
         self.repo = ElectionRepository(election_store, vote_store)
 
-        # session user (lives as long as this Application instance)
-        self.user = Person()  # Person should generate an id by default
+        self.broadcast_new_election = broadcast_new_election
 
         self.root = Tk()
         self.root.title("Democracy")
@@ -66,6 +74,8 @@ class Application:
         self.election_store.add(election)
 
         self.list_frame.load(self.repo.get_all())
+
+        self.broadcast_new_election(election)
 
     def _on_select(self, election_id):
         """


### PR DESCRIPTION
1. Instead of a global JSON stores (for elections and votes), there is a JSON store for every user. Since you start the application as a new user every single time, this implies that you will always start with empty stores. For demo purposes this is not a problem.
2. When an election is created, this is broadcast in a election creation message to the IPV8 overlay.
3. When an election creation message is received, the user verifies that is has not been previously received and add it to the Election JSON store.
4. Periodically all known elections are forwarded to neighbours to check they are up-to-date. This is especially relevant for users that joined after some elections were broadcasted.